### PR TITLE
Added units to headers in tables

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 =======
 History
 =======
+2023.9.26 -- Added units to header in tables, and bugfixes.
+    * The headers for table columns now include units when generated automatically when
+      writing results. Existing columns are not changed.
+    * Changed the join step image and added the code to enable deleting it.
+    * Fixed an issue with the sizie of subwindows in edit dialogs
+      
 2023.8.30 -- Added support for keyed columns in table output
     * Caught errors when writing out the final structures for viewing and improved
       messages in such cases.

--- a/seamm/node.py
+++ b/seamm/node.py
@@ -540,7 +540,9 @@ class Node(collections.abc.Hashable):
                     )
             elif handling == "Create a new system and configuration":
                 system = system_db.create_system()
-                configuration = system.create_configuration()
+                configuration = system.copy_configuration(
+                    configuration=same_as, make_current=True
+                )
             else:
                 raise ValueError(
                     f"Do not understand how to handle the structure: '{handling}'"
@@ -1114,6 +1116,12 @@ class Node(collections.abc.Hashable):
                     for ckey, value in data[key].items():
                         keyed_column = column.replace("{key}", ckey)
                         if keyed_column not in table.columns:
+                            if "units" in result_metadata:
+                                units = result_metadata["units"]
+                                if "units" in results[key]:
+                                    units = results[key]["units"]
+                                keyed_column += f" ({units})"
+                        if keyed_column not in table.columns:
                             if result_metadata["dimensionality"] == "scalar":
                                 kind = result_metadata["type"]
                                 if kind == "boolean":
@@ -1168,6 +1176,12 @@ class Node(collections.abc.Hashable):
                                     value, separators=(",", ":")
                                 )
                 else:
+                    if column not in table.columns:
+                        if "units" in result_metadata:
+                            units = result_metadata["units"]
+                            if "units" in results[key]:
+                                units = results[key]["units"]
+                            column += f" ({units})"
                     if column not in table.columns:
                         if result_metadata["dimensionality"] == "scalar":
                             kind = result_metadata["type"]

--- a/seamm/tk_join_node.py
+++ b/seamm/tk_join_node.py
@@ -19,7 +19,7 @@ class TkJoin(seamm.TkNode):
     }
 
     def __init__(
-        self, tk_flowchart=None, node=None, canvas=None, x=120, y=20, w=10, h=10
+        self, tk_flowchart=None, node=None, canvas=None, x=120, y=20, w=30, h=30
     ):
         """Initialize a node
 
@@ -32,7 +32,7 @@ class TkJoin(seamm.TkNode):
     def draw(self):
         """Draw the node on the given canvas, making it visible"""
         # Remove any graphics items
-        self.undraw()
+        # self.undraw()
 
         # the outline
         x0 = self.x - self.w / 2
@@ -45,8 +45,28 @@ class TkJoin(seamm.TkNode):
             x1,
             y1,
             tags=[self.tag, "type=outline"],
-            fill="black",
+            fill="white",
         )
 
         for direction, edge in self.connections():
             edge.move()
+
+    def right_click(self, event):
+        """
+        Handles the right click event on the node.
+
+        Parameters
+        ----------
+        event : Tk Event
+
+        Returns
+        -------
+        None
+
+        See Also
+        --------
+        TkGaussian.edit
+        """
+
+        super().right_click(event)
+        self.popup_menu.tk_popup(event.x_root, event.y_root, 0)

--- a/seamm/tk_node.py
+++ b/seamm/tk_node.py
@@ -399,7 +399,7 @@ class TkNode(collections.abc.MutableMapping):
             # Main frame holding the widgets
             frame = ttk.Frame(notebook)
             self["frame"] = frame
-            notebook.add(frame, text="Parameters", sticky=tk.NW)
+            notebook.add(frame, text="Parameters", sticky=tk.NSEW)
         elif widget == "frame":
             # Create a frame to hold everything
             frame = ttk.Frame(self.dialog.interior())


### PR DESCRIPTION
* The headers for table columns now include units when generated automatically when writing results. Existing columns are not changed.
* Changed the join step image and added the code to enable deleting it.
* Fixed an issue with the sizie of subwindows in edit dialogs
