### PR TITLE
Allows capital letters in variables and columns for results

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2024.7.21 -- Allows capital letters in variables and columns for results
+    * Allows capital letters for the variables, column names, etc. that results are
+      stored in. For example, 'T', 'P', and 'V'.
+      
 2024.6.27 -- Added support for using local data files.
     * Added support in the Flowchart and Node classes for using local data files for
       e.g. forcefields. This allows the user to specify a local file, which is copied to

--- a/seamm/flowchart.py
+++ b/seamm/flowchart.py
@@ -78,6 +78,7 @@ class Flowchart(object):
 
         # And the root directory and other information
         self.root_directory = directory
+        self._data_path = None
         self.in_jobserver = False
 
         # And the parser associated with this flowchart

--- a/seamm/tk_node.py
+++ b/seamm/tk_node.py
@@ -748,7 +748,7 @@ class TkNode(collections.abc.MutableMapping):
                             w_variable.insert(0, tmp["variable"])
                         else:
                             self.tk_var[key].set(0)
-                            w_variable.insert(0, key.lower().replace(" ", "_"))
+                            w_variable.insert(0, key.replace(" ", "_"))
 
                         if w_table is not None:
                             if "table" in tmp:
@@ -756,7 +756,7 @@ class TkNode(collections.abc.MutableMapping):
                                 w_column.insert(0, tmp["column"])
                             else:
                                 w_table.set("")
-                                w_column.insert(0, key.lower().replace("_", " "))
+                                w_column.insert(0, key.replace("_", " "))
 
                         if w_property is not None:
                             if "property" in tmp:
@@ -776,9 +776,9 @@ class TkNode(collections.abc.MutableMapping):
                     else:
                         self.logger.debug("  resetting widgets")
                         self.tk_var[key].set(0)
-                        w_variable.insert(0, key.lower().replace(" ", "_"))
+                        w_variable.insert(0, key.replace(" ", "_"))
                         if w_column is not None:
-                            w_column.insert(0, key.lower().replace("_", " "))
+                            w_column.insert(0, key.replace("_", " "))
 
             # Reset the parameters, if any
             if self.node.parameters is not None:
@@ -1065,7 +1065,7 @@ class TkNode(collections.abc.MutableMapping):
             table.cell(row, 6, w)
             widgets.append(w)
             e = ttk.Entry(frame, width=15)
-            e.insert(0, key.lower().replace(" ", "_"))
+            e.insert(0, key.replace(" ", "_"))
             table.cell(row, 7, e)
             widgets.append(e)
 
@@ -1083,7 +1083,7 @@ class TkNode(collections.abc.MutableMapping):
             w.bind("<Return>", self._table_cb)
             w.bind("<FocusOut>", self._table_cb)
             e = ttk.Entry(frame, width=15)
-            e.insert(0, key.lower().replace("_", " "))
+            e.insert(0, key.replace("_", " "))
             table.cell(row, 10, e)
             widgets.append(e)
 


### PR DESCRIPTION
* Allows capital letters for the variables, column names, etc. that results are stored in. For example, 'T', 'P', and 'V'.