### PR TITLE
Updating standard parameters for systems and configurations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2024.7.28 -- Updating standard parameters for systems and configurations
+    * Cleaned up and add to the standard parameters used for naming system and
+      configurations. 'title' refers to the title in the file, is it exists.
+      
 2024.7.21 -- Allows capital letters in variables and columns for results
     * Allows capital letters for the variables, column names, etc. that results are
       stored in. For example, 'T', 'P', and 'V'.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@ History
 =======
 2024.7.28 -- Updating standard parameters for systems and configurations
     * Cleaned up and add to the standard parameters used for naming system and
-      configurations. 'title' refers to the title in the file, is it exists.
+      configurations. 'title' refers to the title in the file, if it exists.
       
 2024.7.21 -- Allows capital letters in variables and columns for results
     * Allows capital letters for the variables, column names, etc. that results are

--- a/seamm/standard_parameters.py
+++ b/seamm/standard_parameters.py
@@ -55,6 +55,7 @@ structure_handling_parameters = {
         "default_units": "",
         "enumeration": (
             "keep current name",
+            "title",
             "use SMILES string",
             "use Canonical SMILES string",
             "use IUPAC name",
@@ -71,11 +72,13 @@ structure_handling_parameters = {
         "default_units": "",
         "enumeration": (
             "keep current name",
+            "title",
             "use SMILES string",
             "use Canonical SMILES string",
             "use IUPAC name",
             "use InChI",
             "use InChIKey",
+            "sequential",
         ),
         "format_string": "s",
         "description": "Configuration name:",


### PR DESCRIPTION
* Cleaned up and add to the standard parameters used for naming system and configurations. 'title' refers to the title in the file, if it exists.