### PR TITLE
Improvements in opening flowcharts

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,15 @@
 =======
 History
 =======
+2024.10.20 -- Improvements in opening flowcharts
+    * Removed directories and files not ending in ".flow" from the list of flowcharts
+      that can be opened.
+    * When getting a flowchart from a previous job, the list of jobs is reversed so
+      the most recent is at the top.
+    * Enhanced the handling of parameters to support e.g. lists of values with the
+      normal units attached. Used in e.g. thermochemistry to allow lists of temperatures
+      and pressures with associated units.
+	
 2024.10.13 -- Bugfix: Issue changing units for some parameters
     * Fixed a problem converting e.g. E_h to kJ/mol in the GUI widgets. The problem
       occurred whenever the conversion was not direct but involved different

--- a/seamm/parameters.py
+++ b/seamm/parameters.py
@@ -357,7 +357,11 @@ class Parameter(collections.abc.MutableMapping):
 
         # and run into pint quantity if requested
         if units and self.units is not None and self.units != "":
-            result = Q_(result, self.units)
+            # Might be a string...
+            if isinstance(result, str):
+                result = (result, self.units)
+            else:
+                result = Q_(result, self.units)
 
         return result
 

--- a/seamm/tk_open.py
+++ b/seamm/tk_open.py
@@ -345,7 +345,7 @@ class TkOpen(collections.abc.MutableMapping):
         self.clear_tree()
         self._data = {}
         tree = self["tree"]
-        for job in job_list:
+        for job in job_list[::-1]:
             iid = tree.insert("", "end", text=f"Job_{job['id']:0>6d}: {job['title']}")
             self._data[iid] = job
 
@@ -375,7 +375,7 @@ class TkOpen(collections.abc.MutableMapping):
         if path is not None:
             tree.delete(*tree.get_children(node))
             for p in sorted(path.iterdir(), key=lambda p: p.name):
-                if p.is_dir() or p.suffix == ".flow":
+                if p.suffix == ".flow":
                     self.insert_node(node, p.name, p)
 
     def reset_dialog(self, event=None):


### PR DESCRIPTION
* Removed directories and files not ending in ".flow" from the list of flowcharts that can be opened.
* When getting a flowchart from a previous job, the list of jobs is reversed so the most recent is at the top.
* Enhanced the handling of parameters to support e.g. lists of values with the normal units attached. Used in e.g. thermochemistry to allow lists of temperatures and pressures with associated units.