### PR TITLE
Bugfix: Incorrect handling of JSON properties

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 =======
 History
 =======
+2024.12.7 -- Bugfix: Incorrect handling of JSON properties
+    * Any properties that were not a scalar had an issue when being transformed to and
+      from JSON. This is now fixed.
+    * Truncated values with known units reasonablt so that they are more readable in
+      tables. For example, 1.23400000001 kJ/mol is now 1.234 kJ/mol.
+      
 2024.11.29 -- Chemical formulas option for system names, cleaner tables.
     * Added chemical formula to possible names for systems and configurations.
     * Truncated results put in tables, based on units, to make more readable.

--- a/seamm/node.py
+++ b/seamm/node.py
@@ -1106,24 +1106,11 @@ class Node(collections.abc.Hashable):
                             else:
                                 factor = Q_(1, current_units).m_as(units)
                                 tmp = scale(data[key], factor)
-                                properties.put(
-                                    _property, json.dumps(tmp, separators=(",", ":"))
-                                )
+                                properties.put(_property, tmp)
                         else:
-                            if result_metadata["dimensionality"] == "scalar":
-                                properties.put(_property, data[key])
-                            else:
-                                properties.put(
-                                    _property,
-                                    json.dumps(data[key], separators=(",", ":")),
-                                )
-                    else:
-                        if result_metadata["dimensionality"] == "scalar":
                             properties.put(_property, data[key])
-                        else:
-                            properties.put(
-                                _property, json.dumps(data[key], separators=(",", ":"))
-                            )
+                    else:
+                        properties.put(_property, data[key])
 
             # Store as JSON
             if "json" in value:
@@ -1299,9 +1286,12 @@ class Node(collections.abc.Hashable):
                                     )
                             else:
                                 if result_metadata["dimensionality"] == "scalar":
-                                    table.at[row_index, column] = round(
-                                        data[key], def_fmt[units]
-                                    )
+                                    if units in def_fmt:
+                                        table.at[row_index, column] = round(
+                                            data[key], def_fmt[units]
+                                        )
+                                    else:
+                                        table.at[row_index, column] = data[key]
                                 else:
                                     table.at[row_index, column] = json.dumps(
                                         data[key], separators=(",", ":")


### PR DESCRIPTION
* Any properties that were not a scalar had an issue when being transformed to and from JSON. This is now fixed.
* Truncated values with known units reasonablt so that they are more readable in tables. For example, 1.23400000001 kJ/mol is now 1.234 kJ/mol.