### PR TITLE
Bugfix: Creating a new configurarion ignored discard structure

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 =======
 History
 =======
+2025.3.4 -- Bugfix: Creating a new configurarion ignored discard structure
+    * Fixed the code to create new structures, which did not correctly handle the
+      standard "Discard the structure" option.
+    * Improved the output when discarding the structure.
+      
 2025.2.24 -- Changed option to "Discard the structure"
     * Changed the standard option to "Discard the structure" to indicate that the
       structure should not be saved in the database.

--- a/seamm/node.py
+++ b/seamm/node.py
@@ -574,7 +574,7 @@ class Node(collections.abc.Hashable):
                 else:
                     handling = "Create a new configuration"
 
-            if handling == "Ignore":
+            if handling == "Discard the structure":
                 system = None
                 configuration = None
             elif handling == "Overwrite the current configuration":

--- a/seamm/standard_parameters.py
+++ b/seamm/standard_parameters.py
@@ -261,7 +261,7 @@ def set_names(system, configuration, P, _first=True, **kwargs):
         handling parameters.
 
     _first : bool
-        Whether this is the first or a subseqnet structure.
+        Whether this is the first or a subsequent structure.
 
     kwargs : {str: str}
         keyword arguments providing values that may be substituted in the names.
@@ -272,7 +272,7 @@ def set_names(system, configuration, P, _first=True, **kwargs):
         The text for printing.
     """
     if P["structure handling"] == "Discard the structure":
-        return ""
+        return "The structure was discarded."
 
     sysname = P["system name"]
     if sysname == "keep current name":
@@ -317,7 +317,7 @@ def set_names(system, configuration, P, _first=True, **kwargs):
         configuration.name = safe_format(confname, **kwargs)
 
     if _first:
-        text = "The first structure "
+        text = "The structure "
 
         handling = P["structure handling"]
         if handling == "Overwrite the current configuration":


### PR DESCRIPTION
* Fixed the code to create new structures, which did not correctly handle the standard "Discard the structure" option.
* Improved the output when discarding the structure.