### PR TITLE
Enhancement when storing results in tables.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 =======
 History
 =======
+2025.5.27 -- Enhancement when storing results in tables.
+    * When storing e.g. diffusivity results in a table, the diffusion constants are
+      keyed by the SMILES of the component. If it is a pure fluid with only one
+      component, this enhancement allows using a column name with the SMILES key, which
+      is useful if running a number of different fluids. Otherwise each has unique
+      columns including the SMILES in the column name.
+
 2025.4.30 -- Bugfix: Error naming systems and configurations
     * Fixed a bug that occurred trying to set the name of a system or configuration to
       early, when it had atoms, causing errors.

--- a/seamm/node.py
+++ b/seamm/node.py
@@ -1169,11 +1169,18 @@ class Node(collections.abc.Hashable):
                 table = table_handle["table"]
 
                 # create the column as needed handling "key"ed columns
-                if "{key}" in column:
+                # Special case: if there is only one key, the value can be put
+                # in the column without a keyed name.
+                if "{key}" in column or isinstance(data[key], dict):
                     if not isinstance(data[key], dict):
                         raise ValueError(
                             f"Data for a keyed column '{column}' is not a dictionary. "
-                            f"{type(data[key])}"
+                            f"{type(data[key]).__name__}"
+                        )
+                    if "{key}" not in column and len(data[key]) > 1:
+                        raise ValueError(
+                            f"Data for column '{column}' has more than one key. "
+                            "The column name should contain a key."
                         )
                     for ckey, value in data[key].items():
                         keyed_column = column.replace("{key}", ckey)


### PR DESCRIPTION
* When storing e.g. diffusivity results in a table, the diffusion constants are keyed by the SMILES of the component. If it is a pure fluid with only one component, this enhancement allows using a column name with the SMILES key, which is useful if running a number of different fluids. Otherwise each has unique columns including the SMILES in the column name.