### PR TITLE
Bugfix: path for custom forcefields in jobs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2025.8.5 -- Bugfix: path for custom forcefields in jobs
+    * When running from the JobServer the path for custom forcefields did not include
+      ~/.seamm.d/data or ~/SEAMM/data. This is now corrected.
+      
 2025.5.27 -- Enhancement when storing results in tables.
     * When storing e.g. diffusivity results in a table, the diffusion constants are
       keyed by the SMILES of the component. If it is a pure fluid with only one

--- a/seamm/flowchart.py
+++ b/seamm/flowchart.py
@@ -113,6 +113,8 @@ class Flowchart(object):
         if value:
             self._data_path = [
                 Path(self.root_directory) / "data",
+                Path.home() / ".seamm.d" / "data",
+                Path.home() / "SEAMM" / "data",
             ]  # path for local data in JobServer
         else:
             self._data_path = [

--- a/seamm/tk_node.py
+++ b/seamm/tk_node.py
@@ -420,6 +420,7 @@ class TkNode(collections.abc.MutableMapping):
 
             # Main frame holding the widgets
             frame = ttk.Frame(notebook)
+            frame.pack(fill=tk.BOTH, expand=True)
             self["frame"] = frame
             notebook.add(frame, text="Parameters", sticky=tk.NSEW)
         elif widget == "frame":


### PR DESCRIPTION
    
* When running from the JobServer the path for custom forcefields did not include ~/.seamm.d/data or ~/SEAMM/data. This is now corrected.