### PR TITLE
Bugfix: Error handling '==' in parameters

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 =======
 History
 =======
+2025.9.5 -- Bugfix: Error handling '==' in parameters
+    * Corrected an issue with "==" as the value of a parameter. The GUI's for handling
+      queries and searching use "==" for equality, but this was misintepreted as
+      indicating a variable or expression to evaluate.
+
 2025.8.27 -- Bugfix: error with missing units for some parameters
     * If the value of a parameter was in the enumeration of possible values, and was a
       numerical value, any units were dropped. Now they are kept, though if the value is

--- a/seamm/node.py
+++ b/seamm/node.py
@@ -454,7 +454,7 @@ class Node(collections.abc.Hashable):
         bool
            True for an expression, False otherwise.
         """
-        return len(value) > 0 and value[0] in ("$", "=")
+        return len(value) > 0 and value[0] in ("$", "=") and value != "=="
 
     def set_uuid(self):
         self._uuid = uuid.uuid4().int

--- a/seamm/parameters.py
+++ b/seamm/parameters.py
@@ -303,7 +303,7 @@ class Parameter(collections.abc.MutableMapping):
         """Is the current value a variable reference or
         expression?"""
         if isinstance(self.value, str) and len(self.value) > 0:
-            return self.value[0] in ("$", "=")
+            return self.value[0] in ("$", "=") and self.value != "=="
         else:
             return False
 


### PR DESCRIPTION
* Corrected an issue with "==" as the value of a parameter. The GUI's for handling queries and searching use "==" for equality, but this was misintepreted as indicating a variable or expression to evaluate.