### PR TITLE
When finding files, return the link not the file pointed at

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 =======
 History
 =======
+2026.3.19 -- When finding files, return the link not the file pointed at
+    * With e.g. the MLFFs it is convenient to create links in e.g. the personal
+      forcefield directory pointing at the (large) model files. If the links have
+      different extensions than the underlying files, it is necessary to return the
+      link, not the underlying file, so that the forcefield type can be correctly
+      identified. This fix makes that happen.
+
 2026.2.26 -- Internal: moving from pkg_resources to importlib.resources
 
 2025.10.22 -- Enhancement for extra keywords

--- a/seamm/node.py
+++ b/seamm/node.py
@@ -480,7 +480,7 @@ class Node(collections.abc.Hashable):
         """Reset the id for node"""
         self._id = None
 
-    def find_data_file(self, filename):
+    def find_data_file(self, filename, follow_links=False):
         """Using the data_path, find a file.
 
         Parameters
@@ -501,7 +501,11 @@ class Node(collections.abc.Hashable):
             tmp = path / filename
             self.logger.debug(f"  trying {tmp}")
             if tmp.exists():
-                return tmp.expanduser().resolve()
+                if follow_links:
+                    return tmp.expanduser().resolve()
+                else:
+                    # resolve() follows link, absolute() leaves .., so use this:
+                    return Path(os.path.abspath(tmp.expanduser()))
         self.logger.debug(f"Did not find {filename}")
         raise FileNotFoundError(f"Data file '{filename}' not found.")
 


### PR DESCRIPTION
* With e.g. the MLFFs it is convenient to create links in e.g. the personal forcefield directory pointing at the (large) model files. If the links have different extensions than the underlying files, it is necessary to return the link, not the underlying file, so that the forcefield type can be correctly identified. This fix makes that happen.