### PR TITLE
Added a helper to find preceding steps in a flowchart

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 =======
 History
 =======
+2026.7.6 -- Added a helper to find preceding steps in a flowchart
+    * ``Node.previous_nodes()`` (and the matching ``TkNode.previous_nodes()``)
+      returns the steps preceding a given step, optionally filtered by type --
+      useful for checking whether a particular kind of step, such as a Model
+      Chemistry step, comes earlier in the flow.
+
 2026.3.19 -- When finding files, return the link not the file pointed at
     * With e.g. the MLFFs it is convenient to create links in e.g. the personal
       forcefield directory pointing at the (large) model files. If the links have

--- a/Makefile
+++ b/Makefile
@@ -104,3 +104,12 @@ install: uninstall ## install the package to the active Python's site-packages
 
 uninstall: clean ## uninstall the package
 	pip uninstall --yes $(MODULE)
+
+.PHONY: update
+update: ## post-release: sync main and dev, reinstall, run checks, push dev
+	git checkout main
+	git pull
+	git checkout dev
+	git merge --ff-only main
+	$(MAKE) lint install test
+	git push

--- a/seamm/node.py
+++ b/seamm/node.py
@@ -903,6 +903,35 @@ class Node(collections.abc.Hashable):
 
         return None
 
+    def previous_nodes(self, node_type=None):
+        """The nodes preceding this one in the flowchart, nearest first.
+
+        Follows the execution ("next") edges backward from this node. Optionally
+        keep only nodes that are instances of ``node_type`` -- handy for checking
+        whether a particular kind of step (e.g. a Model Chemistry step) comes
+        earlier in the flow, either as ``node.previous_nodes(SomeStep)`` or by
+        testing membership in ``[type(n) for n in node.previous_nodes()]``.
+
+        Parameters
+        ----------
+        node_type : type or tuple of types, optional
+            If given, return only preceding nodes that are instances of it.
+
+        Returns
+        -------
+        [Node]
+            The preceding nodes, nearest first. May include the flowchart's
+            start node.
+        """
+        nodes = []
+        node = self.previous()
+        while node is not None:
+            nodes.append(node)
+            node = node.previous()
+        if node_type is not None:
+            nodes = [node for node in nodes if isinstance(node, node_type)]
+        return nodes
+
     def get_input(self):
         """Return the input from this subnode, usually used for
         building up the input for the executable."""

--- a/seamm/tk_node.py
+++ b/seamm/tk_node.py
@@ -549,6 +549,15 @@ class TkNode(collections.abc.MutableMapping):
         for direction, edge in self.connections():
             edge.move()
 
+    def previous_nodes(self, node_type=None):
+        """The nodes preceding this one in the flowchart, nearest first.
+
+        Identical to :meth:`seamm.Node.previous_nodes`, delegating to the
+        non-graphical node so the interface is the same whether called on a
+        graphical (Tk) or non-graphical node. Returns non-graphical nodes.
+        """
+        return self.node.previous_nodes(node_type=node_type)
+
     def edit(self):
         """Present a dialog for editing this step's parameters.
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for seamm.Node helpers that don't need a full flowchart."""
+
+import seamm
+
+
+class _Chain:
+    """Minimal stand-in exposing previous(), to exercise previous_nodes()."""
+
+    def __init__(self, prev):
+        self._prev = prev
+
+    def previous(self):
+        return self._prev
+
+
+class _A(_Chain):
+    pass
+
+
+class _B(_Chain):
+    pass
+
+
+def test_previous_nodes_order():
+    a = _A(None)
+    b = _B(a)
+    c = _A(b)
+    # previous_nodes only uses previous(); call it with our stand-in as self.
+    assert seamm.Node.previous_nodes(c) == [b, a]
+    assert seamm.Node.previous_nodes(a) == []
+
+
+def test_previous_nodes_type_filter():
+    a = _A(None)
+    b = _B(a)
+    c = _A(b)
+    assert seamm.Node.previous_nodes(c, _A) == [a]
+    assert seamm.Node.previous_nodes(c, _B) == [b]
+    assert seamm.Node.previous_nodes(c, (_A, _B)) == [b, a]


### PR DESCRIPTION
* `Node.previous_nodes()` (and the matching `TkNode.previous_nodes()`) returns the steps preceding a given step, optionally filtered by type -- useful for checking whether a particular kind of step, such as a Model Chemistry step, comes earlier in the flow.