### PR TITLE
Bugfix: sanitize '/' in model chemistry names; {model} in result names

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,17 @@
 =======
 History
 =======
+2026.7.28.1 -- Bugfix: sanitize '/' in model chemistry names; {model} in result names
+    * ``Node.model`` now collapses any extra ``/`` in a model-chemistry string
+      onto ``-``, keeping only the last ``/`` as the method/basis separator.
+      This fixes model names such as ORCA's ``REVDSD-PBEP86-D4/2021`` functional
+      combined with a basis set, which previously produced an ambiguous name
+      like ``REVDSD-PBEP86-D4/2021/def2-QZVPP``.
+    * ``{model}`` can now be used in the ``variable``, ``table``, and ``column``
+      names of a step's results, substituted with the current model chemistry.
+      This was already supported for the database ``property`` name; it is now
+      consistent across all the places a result can be saved.
+
 2026.7.28 -- file_path(): read-only cross-job references, no more sandboxing
     * ``Node.file_path()`` no longer restricts absolute paths to within the
       current job when running under a jobserver. That check was inconsistent

--- a/seamm/node.py
+++ b/seamm/node.py
@@ -344,6 +344,13 @@ class Node(collections.abc.Hashable):
 
     @model.setter
     def model(self, value):
+        # Model chemistries are conventionally "method/basis", but the method
+        # itself -- e.g. an ORCA functional like "revDSD-PBEP86-D4/2021" -- can
+        # contain its own '/'. Treat the last '/' as the method/basis separator
+        # and collapse any earlier ones to '-' so the name stays unambiguous.
+        if value is not None and "/" in value:
+            *rest, last = value.split("/")
+            value = "-".join(rest) + "/" + last
         self._model = value
 
     @property
@@ -1340,7 +1347,9 @@ class Node(collections.abc.Hashable):
             # Store in a variable
             if "variable" in value:
                 # Name of the variable
-                variable = self.get_value(value["variable"])
+                variable = self.get_value(
+                    value["variable"].replace("{model}", str(self.model))
+                )
 
                 self.logger.debug(f"setting '{variable}' = {data[key]} (key={key})")
 
@@ -1361,8 +1370,12 @@ class Node(collections.abc.Hashable):
 
             # Store in a table
             if "table" in value:
-                tablename = self.get_value(value["table"])
-                column = self.get_value(value["column"])
+                tablename = self.get_value(
+                    value["table"].replace("{model}", str(self.model))
+                )
+                column = self.get_value(
+                    value["column"].replace("{model}", str(self.model))
+                )
                 # Does the table exist?
                 if not self.variable_exists(tablename):
                     # Create the table if allowed to.

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -160,3 +160,40 @@ def test_other_job_path_requires_jobs_root(tmp_path):
     node = _FakeNode(wd=this_job / "3", job_path=this_job)
     with pytest.raises(ValueError, match="Jobs"):
         seamm.Node._other_job_path(node, 5)
+
+
+# ---------------------------------------------------------------------
+# model setter -- collapsing '/' in the method onto '-', keeping the
+# method/basis separator as the last '/'.
+# ---------------------------------------------------------------------
+class _FakeModelNode:
+    """Exposes the real model property on a bare object."""
+
+    model = seamm.Node.model
+
+    def __init__(self):
+        self._model = None
+
+
+def test_model_setter_no_slash_unchanged():
+    node = _FakeModelNode()
+    node.model = "PM7"
+    assert node.model == "PM7"
+
+
+def test_model_setter_single_slash_unchanged():
+    node = _FakeModelNode()
+    node.model = "mp2/6-31g"
+    assert node.model == "mp2/6-31g"
+
+
+def test_model_setter_collapses_slash_in_method():
+    node = _FakeModelNode()
+    node.model = "REVDSD-PBEP86-D4/2021/def2-QZVPP"
+    assert node.model == "REVDSD-PBEP86-D4-2021/def2-QZVPP"
+
+
+def test_model_setter_none_unchanged():
+    node = _FakeModelNode()
+    node.model = None
+    assert node.model is None


### PR DESCRIPTION
* `Node.model` now collapses any extra `/` in a model-chemistry string onto
  `-`, keeping only the last `/` as the method/basis separator. This fixes
  model names such as ORCA's `REVDSD-PBEP86-D4/2021` functional combined
  with a basis set, which previously produced an ambiguous name like
  `REVDSD-PBEP86-D4/2021/def2-QZVPP`.
* `{model}` can now be used in the `variable`, `table`, and `column` names
  of a step's results, substituted with the current model chemistry. This
  was already supported for the database `property` name; it is now
  consistent across all the places a result can be saved.