### PR TITLE
Bugfix: no way to trust a self-signed dashboard TLS certificate

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,22 @@
 =======
 History
 =======
+2026.8.11 -- Bugfix: no way to trust a self-signed dashboard TLS certificate
+    * ``dashboards.ini`` gained a per-dashboard ``verify`` key (see
+      ``seamm_dashboard_client`` ``2026.8.11``): blank/absent -- unchanged
+      normal certificate verification; ``true``/``false`` -- verify
+      normally or not at all; anything else is a path to a certificate
+      file to verify against instead of the system trust store -- e.g. a
+      self-signed ``seamm_webui`` certificate, which had no way to be
+      trusted at all before this, hard-failing login with
+      ``SSLCertVerificationError``. The "Add Dashboard" dialog gained a
+      matching "Verify SSL" field, and its Protocol choices now include
+      ``https``.
+    * ``protocol`` in ``dashboards.ini`` was already unused at connection
+      time (only the scheme literally in ``url`` matters) -- unchanged,
+      but worth knowing if a dashboard entry has ``protocol = http`` and
+      ``url = https://...`` disagreeing, since only ``url`` is honored.
+
 2026.8.10 -- Queue picker in the job submission dialog, and two dashboard-switching bugs
     * The submit dialog now offers a Queue picker (which cluster, or a
       local queue, the JobServer should route the job to) when the

--- a/seamm/dashboard_handler.py
+++ b/seamm/dashboard_handler.py
@@ -22,6 +22,30 @@ import seamm_util
 logger = logging.getLogger(__name__)
 
 
+def _parse_verify(value):
+    """Interpret dashboards.ini's optional per-dashboard "verify" key into
+    what ``seamm_dashboard_client.Dashboard(verify=...)`` expects.
+
+    Empty/absent -> ``True`` (default: normal certificate verification
+    against the system trust store, matching every dashboard from before
+    this key existed). "false"/"no"/"0" (case-insensitive) -> ``False``
+    (disable verification entirely -- insecure, only for a trusted
+    network). "true"/"yes"/"1" -> ``True`` explicitly. Anything else is a
+    path to a certificate/CA bundle to verify against instead -- e.g. a
+    self-signed ``seamm_webui`` certificate (its ``tls.py`` generates one
+    for any non-loopback bind, since a cluster-internal host has no
+    browser-trusted CA to get a real one from).
+    """
+    if not value:
+        return True
+    normalized = value.strip().lower()
+    if normalized in ("false", "no", "0"):
+        return False
+    if normalized in ("true", "yes", "1"):
+        return True
+    return str(Path(value).expanduser())
+
+
 def safe_filename(filename):
     if filename[0] == "~":
         path = Path(filename).expanduser()
@@ -116,9 +140,17 @@ class DashboardHandler(object):
                 result.append(section)
         return sorted(result)
 
-    def add_dashboard(self, name, url, protocol):
-        "Add a new dashboard to the config file"
-        self.config[name] = {"url": url, "protocol": protocol}
+    def add_dashboard(self, name, url, protocol, verify=""):
+        """Add a new dashboard to the config file.
+
+        Parameters
+        ----------
+        verify : str = ""
+            See ``_parse_verify`` for the accepted forms (blank/true/
+            false/a certificate path). Stored as given (not yet parsed) --
+            ``get_dashboard`` parses it at connection time.
+        """
+        self.config[name] = {"url": url, "protocol": protocol, "verify": verify}
         self.save_configuration()
 
     def get_all_status(self):
@@ -189,9 +221,15 @@ class DashboardHandler(object):
         """
         user, passwd = self.get_credentials(name)
         url = self.config[name]["url"]
+        verify = _parse_verify(self.config[name].get("verify", ""))
 
         return seamm_dashboard_client.Dashboard(
-            name, url, username=user, password=passwd, user_agent=self.user_agent
+            name,
+            url,
+            username=user,
+            password=passwd,
+            user_agent=self.user_agent,
+            verify=verify,
         )
 
     def rename_dashboard(self, old, new):
@@ -219,8 +257,13 @@ class DashboardHandler(object):
 
     def update(self, dashboard):
         "Update the dashboard with that given."
+        verify = dashboard.verify
+        # Round-trips through _parse_verify: True/False become the literal
+        # strings it already recognizes; a certificate path is a string
+        # already and passes through unchanged.
         self.config[dashboard.name] = {
             "url": dashboard.url,
             "protocol": "http",
+            "verify": str(verify) if isinstance(verify, bool) else verify,
         }
         self.save_configuration()

--- a/seamm/tk_job_handler.py
+++ b/seamm/tk_job_handler.py
@@ -120,19 +120,28 @@ class TkJobHandler(object):
         name = sw.LabeledEntry(d, labeltext="Name", width=50)
         url = sw.LabeledEntry(d, labeltext="URL")
         protocol = sw.LabeledCombobox(
-            d, labeltext="Protocol", values=["http", "sshtunnel"]
+            d, labeltext="Protocol", values=["http", "https", "sshtunnel"]
         )
         protocol.set("http")
+        # TLS verification -- blank (default, normal system-trust-store
+        # verification), true/false, or a path to a certificate/CA bundle
+        # to verify against instead (e.g. a self-signed seamm_webui
+        # certificate for a non-loopback bind -- see its tls.py). Left
+        # blank for the common https-with-a-real-CA case, so this doesn't
+        # add a required field to the common path.
+        verify = sw.LabeledEntry(d, labeltext="Verify SSL (blank/true/false/cert path)")
 
         w["name"] = name
         w["url"] = url
         w["protocol"] = protocol
+        w["verify"] = verify
 
         name.grid(row=0, column=0, sticky=tk.EW)
         url.grid(row=1, column=0, sticky=tk.EW)
         protocol.grid(row=2, column=0, sticky=tk.W)
+        verify.grid(row=3, column=0, sticky=tk.EW)
 
-        sw.align_labels([name, url, protocol])
+        sw.align_labels([name, url, protocol, verify])
 
         dialog.activate(geometry="centerscreenfirst")
 
@@ -823,6 +832,7 @@ class TkJobHandler(object):
             name = w["name"].get()
             url = w["url"].get()
             protocol = w["protocol"].get()
+            verify = w["verify"].get()
 
             if name in self.config:
                 messagebox.showwarning(
@@ -837,7 +847,7 @@ class TkJobHandler(object):
             dialog.deactivate(result)
 
             # Now add to the configuration
-            self.dashboard_handler.add_dashboard(name, url, protocol)
+            self.dashboard_handler.add_dashboard(name, url, protocol, verify)
 
             # And reset the list in the dashboard combobox
             c = self["dashboard"]

--- a/tests/test_dashboard_handler.py
+++ b/tests/test_dashboard_handler.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for dashboard_handler.py's TLS "verify" support.
+
+Added for a real dashboard: seamm_webui generates a self-signed
+certificate for a non-loopback bind (its tls.py) -- without a way to tell
+a dashboard to trust that specific certificate, connecting to it over
+https fails with a hard SSL verification error (requests' own default).
+"""
+
+import configparser
+
+import pytest  # noqa: F401
+
+from seamm.dashboard_handler import DashboardHandler, _parse_verify
+
+# --- _parse_verify: pure function, no side effects -------------------------
+
+
+def test_parse_verify_blank_defaults_true():
+    assert _parse_verify("") is True
+    assert _parse_verify(None) is True
+
+
+@pytest.mark.parametrize("value", ["false", "False", "FALSE", "no", "No", "0"])
+def test_parse_verify_false_values(value):
+    assert _parse_verify(value) is False
+
+
+@pytest.mark.parametrize("value", ["true", "True", "TRUE", "yes", "Yes", "1"])
+def test_parse_verify_true_values(value):
+    assert _parse_verify(value) is True
+
+
+def test_parse_verify_path_passes_through():
+    assert _parse_verify("/path/to/webui.crt") == "/path/to/webui.crt"
+
+
+def test_parse_verify_expands_user():
+    import os
+
+    home = os.path.expanduser("~")
+    assert _parse_verify("~/webui.crt") == f"{home}/webui.crt"
+
+
+# --- DashboardHandler.add_dashboard / get_dashboard -------------------------
+
+
+def _bare_handler(tmp_path, monkeypatch):
+    """A DashboardHandler with no real filesystem/credentials touched --
+    bypasses __init__ (which reads seamm_util's global options and
+    ~/.seamm.d/seammrc) and wires up just what add_dashboard/get_dashboard
+    need, pointed at an isolated tmp_path config.
+
+    get_credentials is stubbed unconditionally (not just around individual
+    get_dashboard() calls): the current_dashboard property auto-selects a
+    "current" dashboard via get_dashboard() the moment nothing is selected
+    yet, and save_configuration() (called by both add_dashboard and
+    update) reads that property -- so it can fire from inside a plain
+    add_dashboard() call too, not only an explicit get_dashboard()."""
+    dh = DashboardHandler.__new__(DashboardHandler)
+    dh.config = configparser.ConfigParser()
+    dh.configfile = tmp_path / "dashboards.ini"
+    dh.user_agent = "test-agent"
+    dh._current_dashboard = None
+    monkeypatch.setattr(dh, "get_credentials", lambda name, ask=None: (None, None))
+    return dh
+
+
+def test_add_dashboard_stores_verify(tmp_path, monkeypatch):
+    dh = _bare_handler(tmp_path, monkeypatch)
+    dh.add_dashboard("molssi10", "https://molssi10.molssi.org:55060", "https", "/x.crt")
+
+    assert dh.config["molssi10"]["verify"] == "/x.crt"
+
+
+def test_add_dashboard_verify_defaults_blank(tmp_path, monkeypatch):
+    dh = _bare_handler(tmp_path, monkeypatch)
+    dh.add_dashboard("dev", "http://localhost:55066", "http")
+
+    assert dh.config["dev"]["verify"] == ""
+
+
+def test_get_dashboard_passes_parsed_verify_to_client(tmp_path, monkeypatch):
+    dh = _bare_handler(tmp_path, monkeypatch)
+    dh.add_dashboard("molssi10", "https://molssi10.molssi.org:55060", "https", "/x.crt")
+
+    dashboard = dh.get_dashboard("molssi10")
+
+    assert dashboard.verify == "/x.crt"
+    assert dashboard.url == "https://molssi10.molssi.org:55060"
+
+
+def test_get_dashboard_no_verify_key_defaults_true(tmp_path, monkeypatch):
+    dh = _bare_handler(tmp_path, monkeypatch)
+    dh.add_dashboard("dev", "http://localhost:55066", "http")
+
+    dashboard = dh.get_dashboard("dev")
+
+    assert dashboard.verify is True
+
+
+def test_update_round_trips_bool_verify(tmp_path, monkeypatch):
+    dh = _bare_handler(tmp_path, monkeypatch)
+    dh.add_dashboard("dev", "http://localhost:55066", "http")
+
+    dashboard = dh.get_dashboard("dev")
+    assert dashboard.verify is True
+
+    dh.update(dashboard)
+    assert dh.config["dev"]["verify"] == "True"
+
+    reloaded = dh.get_dashboard("dev")
+    assert reloaded.verify is True


### PR DESCRIPTION
* `dashboards.ini` gained a per-dashboard `verify` key (see `seamm_dashboard_client`'s `2026.8.11` release, molssi-seamm/seamm_dashboard_client#17): blank/absent -- unchanged normal certificate verification; `true`/`false` -- verify normally or not at all; anything else is a path to a certificate file to verify against instead of the system trust store -- e.g. a self-signed `seamm_webui` certificate, which had no way to be trusted at all before this, hard-failing login with `SSLCertVerificationError`. The "Add Dashboard" dialog gained a matching "Verify SSL" field, and its Protocol choices now include `https`.
* `protocol` in `dashboards.ini` was already unused at connection time (only the scheme literally in `url` matters) -- unchanged, but worth knowing if a dashboard entry has `protocol = http` and `url = https://...` disagreeing, since only `url` is honored.

Note: this depends on `seamm_dashboard_client` 2026.8.11 (PR #17, not yet merged/released) -- CI here may show red until that's on PyPI, then should go green on its own without any further change.